### PR TITLE
Fix error handling for many adapters

### DIFF
--- a/lib/adapters/LiveScript.coffee
+++ b/lib/adapters/LiveScript.coffee
@@ -9,6 +9,13 @@ class LiveScript extends Adapter
     @output = 'js'
 
   _render: (str, options) ->
-    W.resolve @compiler.compile(str, options)
+    compile => @compiler.compile(str, options)
+
+  # private
+  
+  compile = (fn) ->
+    try res = fn()
+    catch err then return W.reject(err)
+    W.resolve(res)
 
 module.exports = LiveScript

--- a/lib/adapters/coco.coffee
+++ b/lib/adapters/coco.coffee
@@ -9,6 +9,13 @@ class Coco extends Adapter
     @output = 'js'
 
   _render: (str, options) ->
-    W.resolve @compiler.compile(str, options)
+    compile => @compiler.compile(str, options)
+
+  # private
+  
+  compile = (fn) ->
+    try res = fn()
+    catch err then return W.reject(err)
+    W.resolve(res)
 
 module.exports = Coco

--- a/lib/adapters/coffee-script.coffee
+++ b/lib/adapters/coffee-script.coffee
@@ -9,6 +9,13 @@ class CoffeeScript extends Adapter
     @output = 'js'
 
   _render: (str, options) ->
-    W.resolve @compiler.compile(str, options)
+    compile => @compiler.compile(str, options)
+
+  # private
+ 
+  compile = (fn) ->
+    try res = fn()
+    catch err then return W.reject(err)
+    W.resolve(res)
 
 module.exports = CoffeeScript

--- a/lib/adapters/csso.coffee
+++ b/lib/adapters/csso.coffee
@@ -10,6 +10,13 @@ class CSSO extends Adapter
 
   _render: (str, options) ->
     options.noRestructure ?= false
-    W.resolve @compiler.justDoIt(str, options.noRestructure)
+    compile => @compiler.justDoIt(str, options.noRestructure)
+
+  # private
+  
+  compile = (fn) ->
+    try res = fn()
+    catch err then return W.reject(err)
+    W.resolve(res)
 
 module.exports = CSSO

--- a/lib/adapters/ejs.coffee
+++ b/lib/adapters/ejs.coffee
@@ -1,7 +1,7 @@
 Adapter = require '../adapter_base'
-W = require 'when'
 path = require 'path'
 fs = require 'fs'
+W = require 'when'
 
 class EJS extends Adapter
 
@@ -11,17 +11,24 @@ class EJS extends Adapter
     @output = 'html'
 
   _render: (str, options) ->
-    W.resolve @compiler.render(str, options)
+    compile => @compiler.render(str, options)
 
   _compile: (str, options) ->
-    W.resolve @compiler.compile(str, options)
+    compile => @compiler.compile(str, options)
 
   _compileClient: (str, options) ->
     options.client = true
-    W.resolve @compiler.compile(str, options).toString()
+    compile => @compiler.compile(str, options).toString()
 
   clientHelpers: (str, options) ->
     runtime_path = path.join(@compiler.__accord_path, 'ejs.min.js')
     return fs.readFileSync(runtime_path, 'utf8')
+
+  # private
+ 
+  compile = (fn) ->
+    try res = fn()
+    catch err then return W.reject(err)
+    W.resolve(res)
 
 module.exports = EJS

--- a/lib/adapters/haml.coffee
+++ b/lib/adapters/haml.coffee
@@ -15,14 +15,21 @@ class HAML extends Adapter
     @output = 'html'
 
   _render: (str, options) ->
-    W.resolve @compiler.compile(str)(options)
+    compile => @compiler.compile(str)(options)
 
   _compile: (str, options) ->
-    W.resolve @compiler.compile(str, options)
+    compile => @compiler.compile(str, options)
 
   # clientHelpers: ->
   #   runtime_path = path.join(@compiler.__accord_path, 'haml.js')
   #   runtime = fs.readFileSync(runtime_path, 'utf8')
   #   return UglifyJS.minify(runtime, { fromString: true }).code
+  
+  # private
+  
+  compile = (fn) ->
+    try res = fn()
+    catch err then return W.reject(err)
+    W.resolve(res)
 
 module.exports = HAML

--- a/lib/adapters/handlebars.coffee
+++ b/lib/adapters/handlebars.coffee
@@ -14,17 +14,17 @@ class Handlebars extends Adapter
   _render: (str, options) ->
     compiler = _.clone(@compiler)
     register_helpers(compiler, options)
-    W.resolve compiler.compile(str)(options)
+    compile => compiler.compile(str)(options)
 
   _compile: (str, options) ->
     compiler = _.clone(@compiler)
     register_helpers(compiler, options)
-    W.resolve compiler.compile(str)
+    compile => compiler.compile(str)
 
   _compileClient: (str, options) ->
     compiler = _.clone(@compiler)
     register_helpers(compiler, options)
-    W.resolve "Handlebars.template(#{compiler.precompile(str)});"
+    compile => "Handlebars.template(#{compiler.precompile(str)});"
 
   clientHelpers: ->
     runtime_path = path.join(@compiler.__accord_path, 'dist/handlebars.runtime.min.js')
@@ -35,5 +35,10 @@ class Handlebars extends Adapter
   register_helpers = (compiler, opts) ->
     compiler.helpers = _.merge(compiler.helpers, opts.helpers) if opts.helpers
     compiler.partials = _.merge(compiler.partials, opts.partials) if opts.partials
+
+  compile = (fn) ->
+    try res = fn()
+    catch err then return W.reject(err)
+    W.resolve(res)
 
 module.exports = Handlebars

--- a/lib/adapters/jade.coffee
+++ b/lib/adapters/jade.coffee
@@ -12,17 +12,24 @@ class Jade extends Adapter
     @output = 'html'
 
   _render: (str, options) ->
-    W.resolve @compiler.render(str, options)
+    compile => @compiler.render(str, options)
 
   _compile: (str, options) ->
-    W.resolve @compiler.compile(str, options)
+    compile => @compiler.compile(str, options)
 
   _compileClient: (str, options) ->
-    W.resolve @compiler.compileClient(str, options)
+    compile => @compiler.compileClient(str, options)
 
   clientHelpers: ->
     runtime_path = path.join(@compiler.__accord_path, 'runtime.js')
     runtime = fs.readFileSync(runtime_path, 'utf8')
     return UglifyJS.minify(runtime, { fromString: true }).code
+
+  # private
+ 
+  compile = (fn) ->
+    try res = fn()
+    catch err then return W.reject(err)
+    W.resolve(res)
 
 module.exports = Jade

--- a/lib/adapters/minify-css.coffee
+++ b/lib/adapters/minify-css.coffee
@@ -9,6 +9,13 @@ class MinifyCSS extends Adapter
     @output = 'css'
 
   _render: (str, options) ->
-    W.resolve (new @compiler(options)).minify(str)
+    compile => (new @compiler(options)).minify(str)
+
+  # private
+  
+  compile = (fn) ->
+    try res = fn()
+    catch err then return W.reject(err)
+    W.resolve(res)
 
 module.exports = MinifyCSS

--- a/lib/adapters/minify-html.coffee
+++ b/lib/adapters/minify-html.coffee
@@ -15,6 +15,13 @@ class MinifyHTML extends Adapter
       collapseWhitespace: true
       removeEmptyAttributes: true
 
-    W.resolve @compiler.minify(str, options)
+    compile => @compiler.minify(str, options)
+
+  # private
+  
+  compile = (fn) ->
+    try res = fn()
+    catch err then return W.reject(err)
+    W.resolve(res)
 
 module.exports = MinifyHTML

--- a/lib/adapters/minify-js.coffee
+++ b/lib/adapters/minify-js.coffee
@@ -10,6 +10,13 @@ class MinifyJS extends Adapter
     @output = 'js'
 
   _render: (str, options) ->
-    W.resolve @compiler.minify(str, _.extend(options, { fromString: true })).code
+    compile => @compiler.minify(str, _.extend(options, { fromString: true })).code
+
+  # private
+  
+  compile = (fn) ->
+    try res = fn()
+    catch err then return W.reject(err)
+    W.resolve(res)
 
 module.exports = MinifyJS

--- a/lib/adapters/mustache.coffee
+++ b/lib/adapters/mustache.coffee
@@ -12,10 +12,10 @@ class Mustache extends Adapter
     @output = 'html'
 
   _render: (str, options) ->
-    W.resolve @compiler.compile(str, options).render(options, options.partials)
+    compile => @compiler.compile(str, options).render(options, options.partials)
 
   _compile: (str, options) ->
-    W.resolve @compiler.compile(str, options)
+    compile => @compiler.compile(str, options)
 
   _compileClient: (str, options) ->
     options.asString = true
@@ -24,5 +24,12 @@ class Mustache extends Adapter
   clientHelpers: ->
     runtime_path = path.join(@compiler.__accord_path, 'web/builds/2.0.0/hogan-2.0.0.min.js')
     return fs.readFileSync(runtime_path, 'utf8')
+
+  # private
+  
+  compile = (fn) ->
+    try res = fn()
+    catch err then return W.reject(err)
+    W.resolve(res)
 
 module.exports = Mustache

--- a/lib/adapters/myth.coffee
+++ b/lib/adapters/myth.coffee
@@ -9,6 +9,13 @@ class Myth extends Adapter
     @output = 'css'
 
   _render: (str, options) ->
-    W.resolve @compiler(str)
+    compile => @compiler(str)
+
+  # private
+  
+  compile = (fn) ->
+    try res = fn()
+    catch err then return W.reject(err)
+    W.resolve(res)
 
 module.exports = Myth

--- a/test/test.coffee
+++ b/test/test.coffee
@@ -77,6 +77,10 @@ describe 'jade', ->
         tpl = eval.call(global, tpl_string)
         should.match_expected(@jade, tpl, lpath, done)
 
+  it 'should correctly handle errors', (done) ->
+    @jade.render("!= nonexistantfunction()")
+      .done(should.not.exist, (-> done()))
+
 describe 'coffeescript', ->
 
   before ->
@@ -103,6 +107,10 @@ describe 'coffeescript', ->
   it 'should not be able to compile', (done) ->
     @coffee.compile()
       .done(((r) -> should.not.exist(r); done()), ((r) -> should.exist(r); done()))
+
+  it 'should correctly handle errors', (done) ->
+    @coffee.render("!   ---@#$$@%#$")
+      .done(should.not.exist, (-> done()))
 
 describe 'stylus', ->
 
@@ -205,6 +213,10 @@ describe 'stylus', ->
       .catch(should.not.exist)
       .done((res) => should.match_expected(@stylus, res, path.join(@path, 'plugins2.styl'), done))
 
+  it 'should correctly handle errors', (done) ->
+    @stylus.render("214m2/3l")
+      .done(should.not.exist, (-> done()))
+
 describe 'ejs', ->
 
   before ->
@@ -266,6 +278,10 @@ describe 'ejs', ->
         tpl_string =  "#{@ejs.clientHelpers()}; var tpl = #{res}; tpl({ foo: 'local' })"
         tpl = eval.call(global, tpl_string)
         should.match_expected(@ejs, tpl, lpath, done)
+
+  it 'should correctly handle errors', (done) ->
+    @ejs.render("<%= wow() %>")
+      .done(should.not.exist, (-> done()))
 
 describe 'markdown', ->
 
@@ -333,6 +349,10 @@ describe 'minify-js', ->
     @minifyjs.compile()
       .done(((r) -> should.not.exist(r); done()), ((r) -> should.exist(r); done()))
 
+  it 'should correctly handle errors', (done) ->
+    @minifyjs.render("@#$%#I$$N%NI#$%I$PQ")
+      .done(should.not.exist, (-> done()))
+
 describe 'minify-css', ->
 
   before ->
@@ -365,6 +385,10 @@ describe 'minify-css', ->
   it 'should not be able to compile', (done) ->
     @minifycss.compile()
       .done(((r) -> should.not.exist(r); done()), ((r) -> should.exist(r); done()))
+
+  it 'should correctly handle errors', (done) ->
+    @minifycss.render("FMWT$SP#TPO%M@#@#M!@@@")
+      .done(should.not.exist, (-> done()))
 
 describe 'minify-html', ->
 
@@ -399,6 +423,10 @@ describe 'minify-html', ->
     @minifyhtml.compile()
       .done(((r) -> should.not.exist(r); done()), ((r) -> should.exist(r); done()))
 
+  it 'should correctly handle errors', (done) ->
+    @minifyhtml.render("<<<{@$@#$")
+      .done(should.not.exist, (-> done()))
+
 describe 'csso', ->
 
   before ->
@@ -431,6 +459,10 @@ describe 'csso', ->
   it 'should not be able to compile', (done) ->
     @csso.compile()
       .done(((r) -> should.not.exist(r); done()), ((r) -> should.exist(r); done()))
+
+  it 'should correctly handle errors', (done) ->
+    @csso.render("wow")
+      .done(should.not.exist, (-> done()))
 
 describe 'mustache', ->
 
@@ -481,6 +513,10 @@ describe 'mustache', ->
       .catch(should.not.exist)
       .done((res) => should.match_expected(@mustache, res, lpath, done))
 
+  it 'should correctly handle errors', (done) ->
+    @mustache.render("{{# !@{!# }}")
+      .done(should.not.exist, (-> done()))
+
 describe 'dogescript', ->
 
   before ->
@@ -507,6 +543,9 @@ describe 'dogescript', ->
   it 'should not be able to compile', (done) ->
     @doge.compile()
       .done(((r) -> should.not.exist(r); done()), ((r) -> should.exist(r); done()))
+
+  # it turns out that it's impossible for dogescript to throw an error
+  # which, honestly, is how it should be. so no test here.
 
 describe 'handlebars', ->
 
@@ -568,6 +607,10 @@ describe 'handlebars', ->
         tpl = eval.call(global, tpl_string)
         should.match_expected(@handlebars, tpl, lpath, done)
 
+  it 'should correctly handle errors', (done) ->
+    @handlebars.render("{{# !@{!# }}")
+      .done(should.not.exist, (-> done()))
+
 describe 'scss', ->
 
   before ->
@@ -600,6 +643,10 @@ describe 'scss', ->
   it 'should not be able to compile', (done) ->
     @scss.compile()
       .done(((r) -> should.not.exist(r); done()), ((r) -> should.exist(r); done()))
+
+  it 'should correctly handle errors', (done) ->
+    @scss.render("!@##%#$#^$")
+      .done(should.not.exist, (-> done()))
 
 describe 'less', ->
 
@@ -634,6 +681,10 @@ describe 'less', ->
     @less.compile()
       .done(((r) -> should.not.exist(r); done()), ((r) -> should.exist(r); done()))
 
+  it 'should correctly handle errors', (done) ->
+    @less.render("!@##%#$#^$")
+      .done(should.not.exist, (-> done()))
+
 describe 'coco', ->
 
   before ->
@@ -660,6 +711,10 @@ describe 'coco', ->
   it 'should not be able to compile', (done) ->
     @coco.compile()
       .done(((r) -> should.not.exist(r); done()), ((r) -> should.exist(r); done()))
+
+  it 'should correctly handle errors', (done) ->
+    @coco.render("!! ---  )I%$_(I(YRTO")
+      .done(should.not.exist, (-> done()))
 
 describe 'livescript', ->
 
@@ -688,6 +743,10 @@ describe 'livescript', ->
     @livescript.compile()
       .done(((r) -> should.not.exist(r); done()), ((r) -> should.exist(r); done()))
 
+  it 'should correctly handle errors', (done) ->
+    @livescript.render("!! ---  )I%$_(I(YRTO")
+      .done(should.not.exist, (-> done()))
+
 describe 'myth', ->
 
   before ->
@@ -714,6 +773,10 @@ describe 'myth', ->
   it 'should not be able to compile', (done) ->
     @myth.compile()
       .done(((r) -> should.not.exist(r); done()), ((r) -> should.exist(r); done()))
+
+  it 'should correctly handle errors', (done) ->
+    @myth.render("!! ---  )I%$_(I(YRTO")
+      .done(should.not.exist, (-> done()))
 
 describe 'haml', ->
 
@@ -752,3 +815,7 @@ describe 'haml', ->
   it 'should not support client compiles', (done) ->
     @haml.compileClient("%p= 'Here comes the ' + thing")
       .done(((r) -> should.not.exist(r); done()), ((r) -> should.exist(r); done()))
+
+  it 'should correctly handle errors', (done) ->
+    @haml.render("%p= wow()")
+      .done(should.not.exist, (-> done()))


### PR DESCRIPTION
A bunch of adapters would actually throw an error rather than returning it into the promise pipeline as it should. This pull request should resolve that for any compiler that did, and add tests to ensure that all compilers have proper error handling.
