### PR TITLE
accord.supports bugfix

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -66,7 +66,7 @@ Docs below should explain the methods executed in the example above.
 
 - `accord.load(string, object)` - loads the compiler named in the first param, npm package with the name must be installed locally, or the optional second param must be the compiler you are after. The second param allows you to load the compiler from elsewhere or load an alternate version if you want, but be careful.
 
-- `accord.supports(string)` - quick test to see if accord supports a certain compiler. accepts a string (name of compiler), returns a boolean.
+- `accord.supports(string)` - quick test to see if accord supports a certain compiler. accepts a string, which is the name of language (like markdown) or a compiler (like marked), returns a boolean.
 
 ##### Accord Adapter Methods
 

--- a/test/test.coffee
+++ b/test/test.coffee
@@ -8,6 +8,8 @@ describe 'base functions', ->
 
   it 'supports should work', ->
     accord.supports('jade').should.be.ok
+    accord.supports('markdown').should.be.ok
+    accord.supports('marked').should.be.ok
     accord.supports('blargh').should.not.be.ok
 
   it 'load should work', ->


### PR DESCRIPTION
Previously, `accord.supports` would only respond to the language name. So for example if you have a compiler for a language like `marked` for markdown, and passed that name to `accord.supports`, it would return false. After this patch it will return true for both language names and adapter names as long as they are the correct ones.
