### PR TITLE
remove index.js & point the "main" at ./lib

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,2 +1,0 @@
-require('coffee-script')
-module.exports = require('./lib')

--- a/package.json
+++ b/package.json
@@ -2,15 +2,14 @@
   "name": "accord",
   "version": "0.0.8",
   "author": "Jeff Escalante <hello@jenius.me>",
-  "description": "A unified interface for compiled languages and templates in javascript",
-  "main": "index.js",
+  "description": "A unified interface for compiled languages and templates in JavaScript",
+  "main": "lib",
   "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/jenius/accord"
   },
   "dependencies": {
-    "coffee-script": "1.7.x",
     "colors": "0.6.x",
     "when": "3.x",
     "lodash": "2.x",
@@ -19,6 +18,7 @@
     "swig": "^1.3.2"
   },
   "devDependencies": {
+    "coffee-script": "1.7.x",
     "mocha": "*",
     "should": "*",
     "swig": "*",


### PR DESCRIPTION
So we can move CoffeeScript into devDependencies since we compile the
JS before publishing anyway.

A nice side effect is this makes accord 100% coffee! - which is (surprisingly) a valid branch name.
