### PR TITLE
Resolve compiler path using require algorithm

### DIFF
--- a/lib/index.coffee
+++ b/lib/index.coffee
@@ -1,7 +1,8 @@
-path = require 'path'
-glob = require 'glob'
-_    = require 'lodash'
-indx = require 'indx'
+path    = require 'path'
+glob    = require 'glob'
+_       = require 'lodash'
+indx    = require 'indx'
+resolve = require 'resolve'
 
 exports.supports = supports = (name) ->
   name = adapter_to_name(name)
@@ -16,7 +17,7 @@ exports.load = (name, custom_path) ->
 
   # get the compiler
   if custom_path
-    compiler = require(custom_path)
+    compiler = require(resolve.sync(path.basename(custom_path), {basedir: custom_path}))
     compiler.__accord_path = custom_path
   else
     try

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "lodash": "2.x",
     "glob": "3.x",
     "uglify-js": "2.x",
-    "indx": "0.1.x"
+    "indx": "0.1.x",
+    "resolve": "~0.6.3"
   },
   "devDependencies": {
     "coffee-script": "1.7.x",

--- a/test/test.coffee
+++ b/test/test.coffee
@@ -19,6 +19,9 @@ describe 'base functions', ->
   it 'load should accept a custom path', ->
     (-> accord.load('jade', path.join(__dirname, '../node_modules/jade'))).should.not.throw()
 
+  it "load should resolve a custom path using require's algorithm", ->
+    (-> accord.load('jade', path.join(__dirname, '../node_modules/jade/missing/path'))).should.not.throw()
+
   it 'all should return all adapters', ->
     accord.all().should.be.type('object')
 


### PR DESCRIPTION
I was having a issue with accord resolving the path for one of the compilers in a roots project. [roots-cms](github.com/carrot/roots-cms) has [roots-cms-client](github.com/carrot/roots-cms-client) as a dependency, and they both share coffeescript as a dependency. Because of how [npm installs dependencies](https://github.com/npm/npm/issues/1341), coffeescript doesn't get installed into `roots-cms/node_modules/roots-cms-client/node_modules`, instead node will see that `roots-cms` shares that dependency and only install it into `roots-cms/node_modules`.

This updates accord's `load` function to resolve the compiler path the same way `require` does using [node-resolve](https://github.com/substack/node-resolve).
