### PR TITLE
fix opts reference issue when renderFile is rapidly called asynchronously

### DIFF
--- a/lib/adapter_base.coffee
+++ b/lib/adapter_base.coffee
@@ -9,6 +9,7 @@ class Adapter
     @_render(str, opts)
 
   renderFile: (file, opts = {}) ->
+    opts = _.clone(opts, true)
     (new File(file))
       .read(encoding: 'utf8')
       .then _.partialRight(@render, _.extend(opts, {filename: file})).bind(@)


### PR DESCRIPTION
The local `opts` argument somehow references the same object if `renderFile` is rapidly called asynchronously. This causes the very last call's `opts` argument to be passed into the compiler for every single function call, instead of each call's discrete set of arguments. We need to deep clone the object to break the reference.
