### PR TITLE
Add support for Bublé transpiler (0.8.x)

### DIFF
--- a/docs/buble.md
+++ b/docs/buble.md
@@ -1,0 +1,18 @@
+# Bublé
+
+Bublé is an ES2015 compiler. It takes your ES2015 JavaScript code and turns it into code that can run in today's environments, including old versions of Node.js and Internet Explorer.
+
+As the name suggests, Bublé is heavily inspired by (and indebted to) Babel – but there are some key differences:
+
+* Bublé limits itself to ES2015 that can be compiled to compact, performant ES5
+* There are no plugins or presets – less extensibility, but also zero configuration
+* Code is only altered where necessary – your formatting and code style remain intact
+* It's comparatively tiny and much faster
+
+## Supported Methods
+
+ - render
+
+## Source Maps
+
+Source maps are not optional in Bublé. You will always get back `sourcemap` on the response object.

--- a/lib/adapters/buble/0.8.x.coffee
+++ b/lib/adapters/buble/0.8.x.coffee
@@ -1,0 +1,30 @@
+Adapter    = require '../../adapter_base'
+path       = require 'path'
+W          = require 'when'
+sourcemaps = require '../../sourcemaps'
+
+class Buble extends Adapter
+  name: 'buble'
+  extensions: ['js']
+  output: 'js'
+  isolated: true
+
+  _render: (str, options) ->
+    options.source = options.filename
+    compile => @engine.transform(str, options)
+
+  # private
+
+  compile = (fn) ->
+    try res = fn()
+    catch err then return W.reject(err)
+
+    data = { result: res.code }
+    if res.map
+      sourcemaps.inline_sources(res.map).then (map) ->
+        data.sourcemap = map
+        return data
+    else
+      W.resolve(data)
+
+module.exports = Buble

--- a/lib/adapters/buble/index.coffee
+++ b/lib/adapters/buble/index.coffee
@@ -1,0 +1,2 @@
+# the index exports the most recent version of the engine
+module.exports = require('./0.8.x')

--- a/package.json
+++ b/package.json
@@ -22,11 +22,11 @@
   },
   "devDependencies": {
     "LiveScript": "latest",
-    "typescript-compiler": "^1.4",
     "acorn": "latest",
     "babel": "latest",
     "babel-core": "latest",
     "babel-preset-es2015": "latest",
+    "buble": "latest",
     "chai": "3.5.0",
     "clean-css": "latest",
     "coco": "latest",
@@ -61,7 +61,8 @@
     "react-tools": "latest",
     "stylus": "latest",
     "swig": "latest",
-    "toffee": "latest"
+    "toffee": "latest",
+    "typescript-compiler": "^1.4"
   },
   "scripts": {
     "test": "mocha test/test.coffee",

--- a/readme.md
+++ b/readme.md
@@ -114,6 +114,7 @@ It's also important to note that accord returns an object rather than a string f
 - [jsx](https://github.com/facebook/react)
 - [cjsx](https://github.com/jsdf/coffee-react-transform)
 - [typescript](http://www.typescriptlang.org/)
+- [buble](https://buble.surge.sh/guide/)
 
 #### Minifiers
 

--- a/test/fixtures/buble/basic.js
+++ b/test/fixtures/buble/basic.js
@@ -1,0 +1,10 @@
+class Test extends TestClass {
+  constructor(greeting) {
+    super();
+    this.greeting = greeting;
+  }
+
+  static defaultGreeting() {
+    return 'hello there!'
+  }
+}

--- a/test/fixtures/buble/expected/basic.js
+++ b/test/fixtures/buble/expected/basic.js
@@ -1,0 +1,16 @@
+var Test = (function (TestClass) {
+  function Test(greeting) {
+    TestClass.call(this);
+    this.greeting = greeting;
+  }
+
+  if ( TestClass ) Test.__proto__ = TestClass;
+  Test.prototype = Object.create( TestClass && TestClass.prototype );
+  Test.prototype.constructor = Test;
+
+  Test.defaultGreeting = function defaultGreeting() {
+    return 'hello there!'
+  };
+
+  return Test;
+}(TestClass));

--- a/test/fixtures/buble/expected/string.js
+++ b/test/fixtures/buble/expected/string.js
@@ -1,0 +1,1 @@
+console.log('foo');

--- a/test/test.coffee
+++ b/test/test.coffee
@@ -1277,6 +1277,47 @@ describe 'babel', ->
       .catch(should.not.exist)
       .done((res) => should.match_expected(@babel, res.result, lpath, done))
 
+describe 'buble', ->
+  before ->
+    @buble = accord.load('buble')
+    @path = path.join(__dirname, 'fixtures', 'buble')
+
+  it 'should expose name, extensions, output, and compiler', ->
+    @buble.extensions.should.be.an.instanceOf(Array)
+    @buble.output.should.be.a('string')
+    @buble.engine.should.be.ok
+    @buble.name.should.be.ok
+
+  it 'should render a string', (done) ->
+    p = path.join(@path, 'string.js')
+    @buble.render("console.log('foo');").catch(should.not.exist)
+      .done((res) => should.match_expected(@buble, res.result, p, done))
+
+  it 'should render a file', (done) ->
+    lpath = path.join(@path, 'basic.js')
+    @buble.renderFile(lpath)
+      .catch(should.not.exist)
+      .done((res) => should.match_expected(@buble, res.result, lpath, done))
+
+  it 'should not be able to compile', (done) ->
+    @buble.compile()
+      .done(((r) -> should.not.exist(r); done()), ((r) ->
+        should.exist(r); done()))
+
+  it 'should correctly handle errors', (done) ->
+    @buble.render("!   ---@#$$@%#$")
+      .done(should.not.exist, (-> done()))
+
+  it 'should generate sourcemaps', (done) ->
+    lpath = path.join(@path, 'basic.js')
+    @buble.renderFile(lpath).done (res) =>
+      res.sourcemap.should.exist
+      res.sourcemap.version.should.equal(3)
+      res.sourcemap.mappings.length.should.be.above(1)
+      res.sourcemap.sources[0].should.equal(lpath)
+      res.sourcemap.sourcesContent.length.should.be.above(0)
+      should.match_expected(@buble, res.result, lpath, done)
+
 describe 'jsx', ->
 
   before ->


### PR DESCRIPTION
This sates my need for a zero-config ES2015 -> ES5 compiler without the hassle of trying to maintain backwards support with Babel 5. [More about Bublé](https://buble.surge.sh/guide/).