### PR TITLE
Convert Babel sourcemap source to absolute path (for consistency).

### DIFF
--- a/lib/adapters/babel/6.x.coffee
+++ b/lib/adapters/babel/6.x.coffee
@@ -45,7 +45,10 @@ class Babel extends Adapter
     if res.map
       # Convert source to absolute path.
       # This is done for consistency with other accord adapters.
-      if res.map.sources then res.map.sources[0] = res.options.filename
+      if res.map.sources
+        dirname = path.dirname(res.options.filename)
+        res.map.sources =
+            res.map.sources.map (source) -> path.join(dirname, source)
 
       sourcemaps.inline_sources(res.map).then (map) ->
         data.sourcemap = map

--- a/lib/adapters/babel/6.x.coffee
+++ b/lib/adapters/babel/6.x.coffee
@@ -16,7 +16,6 @@ class Babel extends Adapter
 
     if options.sourcemap is true then options.sourceMaps = true
     options.sourceFileName = filename
-    options.sourceRoot = '/'
     delete options.sourcemap
 
     # Babel will crash if you pass any keys others than ones they accept in the
@@ -44,7 +43,10 @@ class Babel extends Adapter
 
     data = { result: res.code }
     if res.map
+      # Convert source to absolute path.
+      # This is done for consistency with other accord adapters.
       if res.map.sources then res.map.sources[0] = res.options.filename
+
       sourcemaps.inline_sources(res.map).then (map) ->
         data.sourcemap = map
         return data

--- a/lib/adapters/babel/6.x.coffee
+++ b/lib/adapters/babel/6.x.coffee
@@ -16,6 +16,7 @@ class Babel extends Adapter
 
     if options.sourcemap is true then options.sourceMaps = true
     options.sourceFileName = filename
+    options.sourceRoot = '/'
     delete options.sourcemap
 
     # Babel will crash if you pass any keys others than ones they accept in the
@@ -28,9 +29,9 @@ class Babel extends Adapter
     allowed_keys = ['filename', 'filenameRelative', 'presets', 'plugins',
     'highlightCode', 'only', 'ignore', 'auxiliaryCommentBefore',
     'auxiliaryCommentAfter', 'sourceMaps', 'inputSourceMap', 'sourceMapTarget',
-    'sourceMapTarget', 'sourceRoot', 'moduleRoot', 'moduleIds', 'moduleId',
-    'getModuleId', 'resolveModuleSource', 'code', 'babelrc', 'ast', 'compact',
-    'comments', 'shouldPrintComment', 'env', 'retainLines', 'extends']
+    'sourceRoot', 'moduleRoot', 'moduleIds', 'moduleId', 'getModuleId',
+    'resolveModuleSource', 'code', 'babelrc', 'ast', 'compact', 'comments',
+    'shouldPrintComment', 'env', 'retainLines', 'extends']
     sanitized_options = pick(options, allowed_keys)
 
     compile => @engine.transform(str, sanitized_options)
@@ -43,6 +44,7 @@ class Babel extends Adapter
 
     data = { result: res.code }
     if res.map
+      if res.map.sources then res.map.sources[0] = res.options.filename
       sourcemaps.inline_sources(res.map).then (map) ->
         data.sourcemap = map
         return data

--- a/test/test.coffee
+++ b/test/test.coffee
@@ -1268,7 +1268,7 @@ describe 'babel', ->
       res.sourcemap.should.exist
       res.sourcemap.version.should.equal(3)
       res.sourcemap.mappings.length.should.be.above(1)
-      res.sourcemap.sources[0].should.equal('basic.js')
+      res.sourcemap.sources[0].should.equal(lpath)
       res.sourcemap.sourcesContent.length.should.be.above(0)
       should.match_expected(@babel, res.result, lpath, done)
 


### PR DESCRIPTION
All other adapters return absolute paths for sources. This change makes Babel also use absolute paths for sources.