### PR TITLE
Updated adapter_base to use fs (with promises) instead of fobject (incompatible GPLv3)

### DIFF
--- a/lib/adapter_base.coffee
+++ b/lib/adapter_base.coffee
@@ -1,10 +1,12 @@
-File         = require 'fobject'
 W            = require 'when'
 clone        = require 'lodash.clone'
 partialRight = require 'lodash.partialright'
 resolve      = require 'resolve'
 path         = require 'path'
 fs           = require 'fs'
+Promise      = require 'bluebird'
+
+readFile     = Promise.promisify fs.readFile
 
 
 class Adapter
@@ -96,8 +98,7 @@ class Adapter
   ###
   renderFile: (file, opts = {}) ->
     opts = clone(opts, true)
-    (new File(file))
-      .read(encoding: 'utf8')
+    readFile(file, 'utf8')
       .then partialRight(@render, Object.assign({ filename: file }, opts)).bind(@)
 
   ###*
@@ -117,8 +118,7 @@ class Adapter
    * @return {Promise}
   ###
   compileFile: (file, opts = {}) ->
-    (new File(file))
-      .read(encoding: 'utf8')
+    readFile(file, 'utf8')
       .then partialRight(@compile, Object.assign({ filename: file }, opts)).bind(@)
 
   ###*
@@ -139,8 +139,7 @@ class Adapter
    * @return {Promise}
   ###
   compileFileClient: (file, opts = {}) ->
-    (new File(file))
-      .read(encoding: 'utf8')
+    readFile(file, 'utf8')
       .then partialRight(@compileClient, Object.assign(opts, {filename: file})).bind(@)
 
   ###*

--- a/lib/adapter_base.coffee
+++ b/lib/adapter_base.coffee
@@ -4,10 +4,7 @@ partialRight = require 'lodash.partialright'
 resolve      = require 'resolve'
 path         = require 'path'
 fs           = require 'fs'
-Promise      = require 'bluebird'
-
-readFile     = Promise.promisify fs.readFile
-
+readFile     = require('when/node/function').lift(fs.readFile)
 
 class Adapter
   ###*

--- a/lib/adapter_base.coffee
+++ b/lib/adapter_base.coffee
@@ -4,7 +4,7 @@ partialRight = require 'lodash.partialright'
 resolve      = require 'resolve'
 path         = require 'path'
 fs           = require 'fs'
-readFile     = require('when/node/function').lift(fs.readFile)
+readFile     = require('when/node/function').lift fs.readFile 
 
 class Adapter
   ###*

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "author": "Jeff Escalante",
   "bugs": "https://github.com/jescalan/accord",
   "dependencies": {
+    "bluebird": "^3.4.6",
     "convert-source-map": "^1.2.0",
-    "fobject": "0.0.4",
     "glob": "^7.0.5",
     "indx": "^0.2.3",
     "lodash.clone": "^4.3.2",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
   "author": "Jeff Escalante",
   "bugs": "https://github.com/jescalan/accord",
   "dependencies": {
-    "bluebird": "^3.4.6",
     "convert-source-map": "^1.2.0",
     "glob": "^7.0.5",
     "indx": "^0.2.3",


### PR DESCRIPTION
Hi Jeff, thanks for your work.  I want to use accord with a project, but fobject (one of the dependencies) is licensed only under GPLv3.  So, I switched it for a promisified fs (using bluebird).  Please consider adding this patch or something similar to make accord purely MIT.  Thanks and regards!