### PR TITLE
refactor: engine requiring

### DIFF
--- a/lib/adapter_base.coffee
+++ b/lib/adapter_base.coffee
@@ -149,7 +149,11 @@ class Adapter
 
 requireEngine = (engineName, customPath) ->
   if customPath?
-    engine = require(resolve.sync(path.basename(customPath), basedir: customPath))
+    try
+      engine = require(resolve.sync(path.basename(customPath), basedir: customPath))
+    catch err
+      engine = require(customPath)
+
     engine.__accord_path = customPath
   else
     try


### PR DESCRIPTION
No need to resolve the custom path again. Resolves https://github.com/pnpm/pnpm/issues/118

Forgive me if I don't understand the logic correctly, but it seems like the custom path can be already used to require the engine. The reason I am proposing this change is because there is an issue open in the pnpm repo. The issue is caused by this line of code in accord.

This is how packages are stored by pnpm:

```
   |   ├─ chalk/1.1.1/
   |   |  ├─ node_modules/
   |   |  |  ├─ chalk        -> ../package
   |   |  |  ├─ ansi-styles/ -> ../../ansi-styles/2.1.0/package
   |   |  |  └─ has-ansi/    -> ../../has-ansi/2.0.0/package
   |   |  └─ package
   |   |     ├─ index.js     => ~/.pnpm-store/chalk/1.1.1/index.js
   |   |     └─ package.json => ~/.pnpm-store/chalk/1.1.1/package.json
```

So `path.basename` will return `package` and so require can't find the engine.
