### PR TITLE
bugfix: `util.inspect` returns a string and obscures some errors

### DIFF
--- a/test/support/all.js
+++ b/test/support/all.js
@@ -37,5 +37,5 @@ global.should.match_expected = function (compiler, content, epath) {
   var expected = parser(fs.readFileSync(expected_path, 'utf8').trim())
   var results = parser(content.trim())
 
-  util.inspect(expected).should.deep.eql(util.inspect(results))
+  expected.should.deep.eql(results)
 }


### PR DESCRIPTION
Noticed this when creating test cases for Pug.

In short, `util.inspect` returns a string representation of an object that only goes two levels deep. This obscures all inequalities that are deeper than two levels.

This causes a number of new failing tests but I believe it is what was originally intended.

In the case of Jade/Pug and other HTML compilers, the `parse5` parser automatically adds missing tags like `html`, `head` and `body`, this means that `util.inspect` never gave enough depth resolution for the actual test cases to be tested (because the test cases began with `<p>` or a similar content element). 