### PR TITLE
Add support for Pug adapter

### DIFF
--- a/lib/adapters/pug/>2.0.0-beta.coffee
+++ b/lib/adapters/pug/>2.0.0-beta.coffee
@@ -1,0 +1,29 @@
+Adapter  = require '../../adapter_base'
+path     = require 'path'
+fs       = require 'fs'
+W        = require 'when'
+UglifyJS = require 'uglify-js'
+
+class Pug extends Adapter
+  name: 'pug'
+  extensions: ['pug']
+  output: 'html'
+  supportedEngines: ['pug']
+
+  _render: (str, options) ->
+    compile => @engine.render(str, options)
+
+  _compile: (str, options) ->
+    compile => @engine.compile(str, options)
+
+  _compileClient: (str, options) ->
+    compile => @engine.compileClient(str, options)
+
+  # private
+
+  compile = (fn) ->
+    try res = fn()
+    catch err then return W.reject(err)
+    W.resolve(result: res)
+
+module.exports = Pug

--- a/lib/adapters/pug/index.coffee
+++ b/lib/adapters/pug/index.coffee
@@ -1,0 +1,2 @@
+# the index exports the most recent version of the engine
+module.exports = require('./>2.0.0-beta')

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "polytest": "0.0.1",
     "postcss": "^5.2.5",
     "postcss-simple-vars": "^3.0.0",
+    "pug": "^2.0.0-beta11",
     "react-tools": "^0.13.3",
     "stylus": "^0.54.5",
     "swig": "^1.4.2",

--- a/test/fixtures/pug/_partial_content.pug
+++ b/test/fixtures/pug/_partial_content.pug
@@ -1,0 +1,1 @@
+p this is whats in the partial

--- a/test/fixtures/pug/async.pug
+++ b/test/fixtures/pug/async.pug
@@ -1,0 +1,2 @@
+strong IMMA FIRIN MAH LAZERS
+p= wow.such

--- a/test/fixtures/pug/basic.pug
+++ b/test/fixtures/pug/basic.pug
@@ -1,0 +1,2 @@
+strong IMMA FIRIN MAH LAZERS
+p= foo

--- a/test/fixtures/pug/client-complex.pug
+++ b/test/fixtures/pug/client-complex.pug
@@ -1,0 +1,13 @@
+- foo = [1,2,3,4]
+each item in foo
+  p= item
+  p!= item
+
+div(class=foo[0])
+.hello such #{wow}
+
+mixin foo(arg)
+  p= arg
+
+.test
+  .foo('hello')

--- a/test/fixtures/pug/client.pug
+++ b/test/fixtures/pug/client.pug
@@ -1,0 +1,2 @@
+p look at my browser-compatibility
+p= foo

--- a/test/fixtures/pug/expected/basic.html
+++ b/test/fixtures/pug/expected/basic.html
@@ -1,0 +1,1 @@
+<strong>IMMA FIRIN MAH LAZERS</strong><p>such options</p>

--- a/test/fixtures/pug/expected/client-complex.html
+++ b/test/fixtures/pug/expected/client-complex.html
@@ -1,0 +1,1 @@
+<p>1</p><p>1</p><p>2</p><p>2</p><p>3</p><p>3</p><p>4</p><p>4</p><div class="1"></div><div class="hello">such local</div><div class="test"><div hello="hello" class="foo"></div></div>

--- a/test/fixtures/pug/expected/client-complex.html
+++ b/test/fixtures/pug/expected/client-complex.html
@@ -1,1 +1,1 @@
-<p>1</p><p>1</p><p>2</p><p>2</p><p>3</p><p>3</p><p>4</p><p>4</p><div class="1"></div><div class="hello">such local</div><div class="test"><div hello="hello" class="foo"></div></div>
+<p>1</p><p>1</p><p>2</p><p>2</p><p>3</p><p>3</p><p>4</p><p>4</p><div class="1"></div><div class="hello">such local</div><div class="test"><div class="foo" hello="hello"></div></div>

--- a/test/fixtures/pug/expected/client.html
+++ b/test/fixtures/pug/expected/client.html
@@ -1,0 +1,7 @@
+function template(locals) {
+var buf = [];
+var jade_mixins = {};
+var jade_interp;
+;var locals_for_with = (locals || {});(function (foo) {
+buf.push("<p>look at my browser-compatibility</p><p>" + (jade.escape(null == (jade_interp = foo) ? "" : jade_interp)) + "</p>");}.call(this,"foo" in locals_for_with?locals_for_with.foo:typeof foo!=="undefined"?foo:undefined));;return buf.join("");
+}

--- a/test/fixtures/pug/expected/client.html
+++ b/test/fixtures/pug/expected/client.html
@@ -1,7 +1,1 @@
-function template(locals) {
-var buf = [];
-var jade_mixins = {};
-var jade_interp;
-;var locals_for_with = (locals || {});(function (foo) {
-buf.push("<p>look at my browser-compatibility</p><p>" + (jade.escape(null == (jade_interp = foo) ? "" : jade_interp)) + "</p>");}.call(this,"foo" in locals_for_with?locals_for_with.foo:typeof foo!=="undefined"?foo:undefined));;return buf.join("");
-}
+<p>look at my browser-compatibility</p><p>such options</p>

--- a/test/fixtures/pug/expected/cstring.html
+++ b/test/fixtures/pug/expected/cstring.html
@@ -1,0 +1,7 @@
+function template(locals) {
+var buf = [];
+var jade_mixins = {};
+var jade_interp;
+;var locals_for_with = (locals || {});(function (foo) {
+buf.push("<p>look at my browser-compatibility</p><p>" + (jade.escape(null == (jade_interp = foo) ? "" : jade_interp)) + "</p>");}.call(this,"foo" in locals_for_with?locals_for_with.foo:typeof foo!=="undefined"?foo:undefined));;return buf.join("");
+}

--- a/test/fixtures/pug/expected/cstring.html
+++ b/test/fixtures/pug/expected/cstring.html
@@ -1,7 +1,1 @@
-function template(locals) {
-var buf = [];
-var jade_mixins = {};
-var jade_interp;
-;var locals_for_with = (locals || {});(function (foo) {
-buf.push("<p>look at my browser-compatibility</p><p>" + (jade.escape(null == (jade_interp = foo) ? "" : jade_interp)) + "</p>");}.call(this,"foo" in locals_for_with?locals_for_with.foo:typeof foo!=="undefined"?foo:undefined));;return buf.join("");
-}
+<p>imma firin mah lazer!</p><p>such options</p>

--- a/test/fixtures/pug/expected/partial.html
+++ b/test/fixtures/pug/expected/partial.html
@@ -1,0 +1,1 @@
+<p>heres a partial</p><p>this is whats in the partial</p>

--- a/test/fixtures/pug/expected/precompile.html
+++ b/test/fixtures/pug/expected/precompile.html
@@ -1,0 +1,1 @@
+<h1>spooderman</h1><p>such options</p>

--- a/test/fixtures/pug/expected/pstring.html
+++ b/test/fixtures/pug/expected/pstring.html
@@ -1,0 +1,1 @@
+<p>why cant I shot web?</p><p>such options</p>

--- a/test/fixtures/pug/expected/rstring.html
+++ b/test/fixtures/pug/expected/rstring.html
@@ -1,0 +1,1 @@
+<p>BLAHHHHH</p><p>such options</p>

--- a/test/fixtures/pug/partial.pug
+++ b/test/fixtures/pug/partial.pug
@@ -1,0 +1,2 @@
+p heres a partial
+include _partial_content

--- a/test/fixtures/pug/precompile.pug
+++ b/test/fixtures/pug/precompile.pug
@@ -1,0 +1,2 @@
+h1 spooderman
+p= foo

--- a/test/test.coffee
+++ b/test/test.coffee
@@ -94,6 +94,65 @@ describe 'jade', ->
     .then (res) ->
       uniq(res).length.should.equal(res.length)
 
+describe 'pug', ->
+
+  before ->
+    @pug = accord.load('pug')
+    @path = path.join(__dirname, 'fixtures', 'pug')
+
+  it 'should expose name, extensions, output, and engine', ->
+    @pug.extensions.should.be.an.instanceOf(Array)
+    @pug.output.should.be.a('string')
+    @pug.engine.should.be.ok
+    @pug.name.should.be.ok
+
+  it 'should render a string', ->
+    @pug.render('p BLAHHHHH\np= foo', { foo: 'such options' })
+      .then((res) => should.match_expected(@pug, res.result, path.join(@path, 'rstring.pug')))
+
+  it 'should render a file', ->
+    lpath = path.join(@path, 'basic.pug')
+    @pug.renderFile(lpath, { foo: 'such options' })
+      .then((res) => should.match_expected(@pug, res.result, lpath))
+
+  it 'should compile a string', ->
+    @pug.compile("p why cant I shot web?\np= foo")
+      .then((res) => should.match_expected(@pug, res.result({foo: 'such options'}), path.join(@path, 'pstring.pug')))
+
+  it 'should compile a file', ->
+    lpath = path.join(@path, 'precompile.pug')
+    @pug.compileFile(lpath)
+      .then((res) => should.match_expected(@pug, res.result({foo: 'such options'}), lpath))
+
+  it 'should client-compile a string', ->
+    @pug.compileClient("p imma firin mah lazer!\np= foo", {foo: 'such options'})
+      .then((res) => should.match_expected(@pug, res.result, path.join(@path, 'cstring.pug')))
+
+  it 'should client-compile a file', ->
+    lpath = path.join(@path, 'client.pug')
+    @pug.compileFileClient(lpath, {foo: 'such options'})
+      .then((res) => should.match_expected(@pug, res.result, lpath))
+
+  it 'should handle external file requests', ->
+    lpath = path.join(@path, 'partial.pug')
+    @pug.renderFile(lpath)
+      .then((res) => should.match_expected(@pug, res.result, lpath))
+
+  it 'should correctly handle errors', ->
+    @pug.render("!= nonexistantfunction()")
+      .catch((err) ->
+        err.message.should.equal('nonexistantfunction is not a function on line 1')
+      )
+
+  it "should handle rapid async calls with different deeply nested locals correctly", ->
+    lpath = path.join(@path, 'async.pug')
+    opts  = {wow: {such: 'test'}}
+    W.map [1..100], (i) =>
+      opts.wow = {such: i}
+      @pug.renderFile(lpath, opts).catch(should.not.exist)
+    .then (res) ->
+      uniq(res).length.should.equal(res.length)
+
 describe 'swig', ->
 
   before ->

--- a/test/test.coffee
+++ b/test/test.coffee
@@ -125,18 +125,32 @@ describe 'pug', ->
       .then((res) => should.match_expected(@pug, res.result({foo: 'such options'}), lpath))
 
   it 'should client-compile a string', ->
-    @pug.compileClient("p imma firin mah lazer!\np= foo", {foo: 'such options'})
-      .then((res) => should.match_expected(@pug, res.result, path.join(@path, 'cstring.pug')))
+    @pug.compileClient("p imma firin mah lazer!\np= foo")
+      .then (res) =>
+        tpl_string = "#{res.result}; template({ foo: 'such options' })"
+        tpl = eval.call(global, tpl_string)
+        should.match_expected(@pug, tpl, path.join(@path, 'cstring.pug'))
 
   it 'should client-compile a file', ->
     lpath = path.join(@path, 'client.pug')
-    @pug.compileFileClient(lpath, {foo: 'such options'})
-      .then((res) => should.match_expected(@pug, res.result, lpath))
+    @pug.compileFileClient(lpath)
+      .then (res) =>
+        tpl_string = "#{res.result}; template({ foo: 'such options' })"
+        tpl = eval.call(global, tpl_string)
+        should.match_expected(@pug, tpl, lpath)
 
   it 'should handle external file requests', ->
     lpath = path.join(@path, 'partial.pug')
     @pug.renderFile(lpath)
       .then((res) => should.match_expected(@pug, res.result, lpath))
+
+  it 'should render complex pug files', ->
+    lpath = path.join(@path, 'client-complex.pug')
+    @pug.compileFileClient(lpath)
+      .then (res) =>
+        tpl_string = "#{res.result}; template({ wow: 'local' })"
+        tpl = eval.call(global, tpl_string)
+        should.match_expected(@pug, tpl, lpath)
 
   it 'should correctly handle errors', ->
     @pug.render("!= nonexistantfunction()")


### PR DESCRIPTION
I thought Pug had a version 1 (same as Jade) but in fact, it only has a version 2 (beta).

I added it anyway. API is the pretty much the same according to the tests, the only major difference is that the client runtime is now inlined by default: https://github.com/pugjs/pug-runtime/issues/29.